### PR TITLE
CVG-1103 add daily and button reset options to wordup

### DIFF
--- a/app/com/timlah/controllers/HomeController.scala
+++ b/app/com/timlah/controllers/HomeController.scala
@@ -158,21 +158,27 @@ class HomeController @Inject()(
 
   def newWordGame() = Action { implicit request: MessagesRequest[AnyContent] =>
     val maybeCookie = request.cookies.get("wordupData")
-    if(maybeCookie.nonEmpty) {
-      if(isCookieExpired(maybeCookie.get)) {
-        println("Cookie expired")
-        minigameWordGameService.reset()
-        minigameWordGameService.setupGame()
-        Redirect(routes.HomeController.currentWordGame())
-      } else {
-        Redirect(routes.HomeController.currentWordGame())
+    maybeCookie match {
+      case Some(cookie) => {
+        if(isCookieExpired(maybeCookie.get)) {
+          // cookie
+          Redirect(routes.HomeController.setupNewWordGame())
+        } else {
+          // cookie active
+          Redirect(routes.HomeController.currentWordGame())
+        }        
       }
-    } else {
-      println("No cookie found")
-      minigameWordGameService.reset()
-      minigameWordGameService.setupGame()
-      Redirect(routes.HomeController.currentWordGame())
+      case None => {
+        // no cookie found
+        Redirect(routes.HomeController.setupNewWordGame())
+      } 
     }
+  }
+
+  def setupNewWordGame() = Action { implicit request: MessagesRequest[AnyContent] =>
+    minigameWordGameService.reset()
+    minigameWordGameService.setupGame()
+    Redirect(routes.HomeController.currentWordGame())
   }
 
   def currentWordGame() = Action { implicit request: MessagesRequest[AnyContent] =>

--- a/app/com/timlah/views/wordgame.scala.html
+++ b/app/com/timlah/views/wordgame.scala.html
@@ -103,7 +103,7 @@
     }
     
     @if(!minigameWordGameService.inProgress) {
-      @helper.form(action = com.timlah.controllers.routes.HomeController.newWordGame(), 'method -> "GET") {
+      @helper.form(action = com.timlah.controllers.routes.HomeController.setupNewWordGame(), 'method -> "GET") {
         <input type="submit" value="New word" />
       }
     }
@@ -127,6 +127,11 @@
       turnsTaken : num
     };
     SaveWordupDataToCookie(wordupCookieData);
+  }
+
+  function SetStreakCookie() {
+    // TODO: Fully implement streak data
+    document.cookie = `wordupStreakData=1; path=/; SameSite=Lax`;
   }
 
   function SaveWordupDataToCookie(data) {

--- a/conf/routes
+++ b/conf/routes
@@ -25,6 +25,7 @@ POST    /contact                    com.timlah.controllers.HomeController.contac
 # Minigame related endpoints
 
 GET     /word-up/new                com.timlah.controllers.HomeController.newWordGame()
+GET     /word-up/restart            com.timlah.controllers.HomeController.setupNewWordGame()
 GET     /word-up/                   com.timlah.controllers.HomeController.currentWordGame()
 POST    /word-up                    com.timlah.controllers.HomeController.continueWordGame()
 


### PR DESCRIPTION
# Purpose of PR
- Word-Up: Introduce a daily cap on words
- Word-Up: Introduce a reset button so people aren't blocked by daily cap on words

## Future Goals
- Word-Up: Introduce streak cookie
- Word-Up: Capture the whole of the last game played, so that when people click away from the site and go back, it displays their previous word attempt.