### PR TITLE
CVG-1109 add search to blog posts

### DIFF
--- a/app/com/timlah/components/search/search.scala.html
+++ b/app/com/timlah/components/search/search.scala.html
@@ -1,0 +1,17 @@
+<!-- Copyright - 2024 alexruix (Alex Ruiz) 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+
+-->
+
+@import scala.concurrent.{Future, ExecutionContext}
+@()
+<link rel="stylesheet"  media="screen" href="@routes.Assets.versioned("stylesheets/components/search/search.css")">
+<div class="group">
+    <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
+        <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0"/>
+      </svg>
+    <input type="search" class="input" id="input" onkeyup="search()" placeholder="Search..">
+</div>

--- a/app/com/timlah/components/search/search.scala.html
+++ b/app/com/timlah/components/search/search.scala.html
@@ -1,11 +1,3 @@
-<!-- Copyright - 2024 alexruix (Alex Ruiz) 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
-
--->
-
 @import scala.concurrent.{Future, ExecutionContext}
 @()
 <link rel="stylesheet"  media="screen" href="@routes.Assets.versioned("stylesheets/components/search/search.css")">

--- a/app/com/timlah/views/blogposts.scala.html
+++ b/app/com/timlah/views/blogposts.scala.html
@@ -1,28 +1,52 @@
 @import com.timlah.models.BlogPost
 @import com.timlah.services.MarkupService
 @import scala.util.matching.Regex
+@import com.timlah.components.search.html.search
 @(blogPosts: Seq[BlogPost], blogCount: Int, markupService: MarkupService)(implicit flash: Flash)
 
 @main("Blog | Timlah's Techs", None) {
-    <div class="content">
-        <p class="text-muted">Blog Posts found: @blogCount</p>
+    @search()
+    <div class="content" id="blogPosts">
+        <p>Blog Posts found: @blogCount</p>
         @blogPosts.reverse.zipWithIndex.map{case (post, i) =>
-            <h1><a class="blog-list-header" href="@com.timlah.controllers.routes.HomeController.blogBySlug(post.slug)">@post.title</a></h1>
-            Written by: <strong>@post.author.username</strong> | Written on: @post.date.day @post.date.monthStr @post.date.year | Estimated reading time:
-        @if(Math.ceil("\\s".r.findAllIn(post.content).length/200).toInt < 1) {
-            less than a minute
-        }else if(Math.ceil("\\s".r.findAllIn(post.content).length/200).toInt == 1){
-            1 minute
-        }else{
-        @Math.ceil("\\s".r.findAllIn(post.content).length/200).toInt minutes
-        }<hr>
-            <p>@Html(markupService.markdownStringToHTML(post.content.take(250)) match {
+            <div>
+                <h1 id="blogTitle"><a class="blog-list-header" href="@com.timlah.controllers.routes.HomeController.blogBySlug(post.slug)">@post.title</a></h1>
+                Written by: <strong>@post.author.username</strong> | Written on: @post.date.day @post.date.monthStr @post.date.year | Estimated reading time:
+                @if(Math.ceil("\\s".r.findAllIn(post.content).length/180).toInt < 1) {
+                    less than a minute
+                }else if(Math.ceil("\\s".r.findAllIn(post.content).length/180).toInt == 1){
+                    1 minute
+                }else{
+                    @Math.ceil("\\s".r.findAllIn(post.content).length/180).toInt minutes
+                }<hr>
+                <p>@Html(markupService.markdownStringToHTML(post.content.take(250)) match {
                     case Left(_) => "Unable to render content at this time"
-                    case Right(s) => s
+                    case Right(s) => { s.take(s.lastIndexOf(" ")) }
                 }) ...
-                <a href="@com.timlah.controllers.routes.HomeController.blogBySlug(post.slug)">Read more...</a>
-            </p>
-        <br/>
+                    <a href="@com.timlah.controllers.routes.HomeController.blogBySlug(post.slug)">Read more...</a>
+                </p>
+                <br/>
+            </div>
         }
     </div>
+    <script>
+        function search() {
+            var input, filter, posts, headers, a, i, search;
+            input = document.getElementById('input');
+            filter = input.value.toUpperCase();
+            posts = document.getElementById("blogPosts");
+            headers = posts.getElementsByTagName('div');
+    
+            // Loop through all list items, and hide those who don't match the search query
+            for (i = 0; i < headers.length; i++) {
+                a = headers[i].getElementsByTagName("a")[0];
+                search = a.textContent || a.innerText;
+                if (search.toUpperCase().indexOf(filter) > -1) {
+                    headers[i].style.display = "";
+                } else {
+                    headers[i].style.display = "none";
+                }
+            }
+        }
+    </script>    
 }

--- a/public/stylesheets/components/search/search.css
+++ b/public/stylesheets/components/search/search.css
@@ -1,0 +1,40 @@
+.group {
+    display: flex;
+    line-height: 28px;
+    align-items: center;
+    position: relative;
+    max-width: 190px;
+   }
+   
+.input {
+    width: 100%;
+    height: 40px;
+    line-height: 28px;
+    padding: 0 1rem;
+    padding-left: 2.5rem;
+    border: 2px solid transparent;
+    border-radius: 8px;
+    outline: none;
+    background-color: #f3f3f4;
+    color: #0d0c22;
+    transition: .3s ease;
+}
+   
+.input::placeholder {
+    color: #9e9ea7;
+}
+   
+.input:focus, input:hover {
+    outline: none;
+    border-color: rgba(234,76,137,0.4);
+    background-color: #fff;
+    box-shadow: 0 0 0 4px rgb(234 76 137 / 10%);
+}
+   
+.icon {
+    position: absolute;
+    left: 1rem;
+    fill: #9e9ea7;
+    width: 1rem;
+    height: 1rem;
+}

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -76,8 +76,8 @@ pre code {
 }
 
 .content {
-    margin-top: 10%;
-    margin-bottom: 10%;
+    margin-top: 7.5%;
+    margin-bottom: 7.5%;
 }
 
 .socials {
@@ -135,6 +135,10 @@ dt label {
     --bs-popover-header-bg: #3f0000;
     --bs-popover-body-color: #000000f2;
     --popover-header-bg:                 shade-color(#000000f2, 6%);
+}
+
+.text-faded {
+    color: #AAAAAA;
 }
 
 .gravatar-hovercard {


### PR DESCRIPTION
# Purpose of PR
- Introduces a new search repeatable component
  - Usage requires a Javascript method called `search()` within the page being embedded
    - This has been done to allow the component to be used in different areas and not be tied to a specific search feature
    - Note to self: As this is being done with Javascript, consider the type of content being passed
- Updates the post content limit to take only as much as the last white space, ensuring it ends on a word of some kind, rather than cutting out halfway through a word.