### PR TITLE
CVG-1113 adds responsive css to word-up

### DIFF
--- a/public/stylesheets/wordup.css
+++ b/public/stylesheets/wordup.css
@@ -1,3 +1,9 @@
+@media screen and (max-width: 1200px) {
+    .keyboard     { display: none;    }
+    .keyboard-row { display: none;    }
+    .keyboard-key { display: none;    }
+}
+
 .wordup-word {
     display:flex; 
     align-items: flex-start;
@@ -66,8 +72,8 @@
 }
 .wordup-stats {
     font-size: x-large;
-
 }
+
 @keyframes spin {
     from {
         transform: rotate(0deg);


### PR DESCRIPTION
# Purpose of PR
- To ensure the mobile view of word-up isn't too bloated with the keyboard
- Will look to move the keyboard to the bottom of the screen stickied, as well as adding an enter button, so mobile users can just press the keys
  - However this requires an update to the functionality of the keys and how users enter their answers